### PR TITLE
fix memory leak in ED-module and ellipse-interface

### DIFF
--- a/src/ED/EDLines.h
+++ b/src/ED/EDLines.h
@@ -50,9 +50,9 @@ public:
 
   /// Destructor
   ~EDLines(){
-    delete lines;
-    delete x;
-    delete y;
+    delete[] lines;
+    delete[] x;
+    delete[] y;
   } //end-EDLines
 
   /// clear
@@ -62,7 +62,7 @@ public:
     capacity *= 2;
     LineSegment *newArr = new LineSegment[capacity];
     memcpy(newArr, lines, sizeof(LineSegment)*noLines);
-    delete lines;
+    delete[] lines;
     lines = newArr;
   } //end-expandCapacity
 

--- a/src/ED/EdgeMap.h
+++ b/src/ED/EdgeMap.h
@@ -37,9 +37,9 @@ public:
 
   // Destructor
   ~EdgeMap(){
-    delete edgeImg;
-    delete pixels;
-    delete segments;
+    delete[] edgeImg;
+    delete[] pixels;
+    delete[] segments;
   } //end-~EdgeMap
 
 

--- a/src/EDInterface.h
+++ b/src/EDInterface.h
@@ -12,6 +12,11 @@ class EDInterface
 	EDLines* edLines = NULL;
 
 public:
+
+	~EDInterface() {
+		delete edgeMap;
+		delete edLines;
+	}
 	// runs EDPF and EDLines, keeps the results in memory
 	void runEDPFandEDLines(const cv::Mat &image);
 

--- a/src/Ellipse.cpp
+++ b/src/Ellipse.cpp
@@ -525,6 +525,7 @@ customEllipse::customEllipse(pix* points, int noPnts)
 	delete[] d;
 	DeallocateMatrix(V, 7);
 	DeallocateMatrix(sol, 7);
+	free(fitPoints);
 }
 
 


### PR DESCRIPTION
When running the library multiple times, especially edge- and line-information isn't properly deleted.
Occured on both MSVC and g++-builds. (g++ version 11.4.0)
This should be fixed with this PR, at least this version does run for days without accumulating excessive memory.
